### PR TITLE
chore: add tierBoostRate to Planet IX bills

### DIFF
--- a/config/bills.json
+++ b/config/bills.json
@@ -3708,7 +3708,8 @@
     "fullDescription": "Planet IX is a pioneering Web3 strategy game that emerged on Polygon in 2021 and rapidly evolved into one of the ecosystem’s largest gaming experiences. Players trade land, expand territories, and stake digital assets, forming a deeply engaged community where nearly 70% of tokens are staked. Now entering its most transformative phase, Planet IX is expanding its universe with AI-powered upgrades, new strategic assets, and advanced in-game mechanics. As part of its evolution, the project is migrating to Base to unlock faster transactions, broader liquidity, and enhanced scalability. Central to this new chapter is the AIX token, designed to power Season 2 with utility, competitive rewards, and elevated DeFi opportunities.",
     "clickUpId": "86agqjvbq",
     "cgId": "planet-ix",
-    "vestingCliff": 2592000
+    "vestingCliff": 2592000,
+    "tierBoostRate": 0
   },
   {
     "index": 8098,
@@ -3763,7 +3764,8 @@
     "fullDescription": "Planet IX is a pioneering Web3 strategy game that emerged on Polygon in 2021 and rapidly evolved into one of the ecosystem’s largest gaming experiences. Players trade land, expand territories, and stake digital assets, forming a deeply engaged community where nearly 70% of tokens are staked. Now entering its most transformative phase, Planet IX is expanding its universe with AI-powered upgrades, new strategic assets, and advanced in-game mechanics. As part of its evolution, the project is migrating to Base to unlock faster transactions, broader liquidity, and enhanced scalability. Central to this new chapter is the AIX token, designed to power Season 2 with utility, competitive rewards, and elevated DeFi opportunities.",
     "clickUpId": "86agqjvbk",
     "cgId": "planet-ix",
-    "vestingCliff": 864000
+    "vestingCliff": 864000,
+    "tierBoostRate": 0
   },
   {
     "index": 8097,

--- a/src/constants/bills.ts
+++ b/src/constants/bills.ts
@@ -1997,6 +1997,7 @@ const bills: BillsConfig[] = [
     clickUpId: '86agqjvbq',
     cgId: 'planet-ix',
     vestingCliff: 2592000, //30 days cliff, instant vesting
+    tierBoostRate: 0,
   },
   {
     index: 8098,
@@ -2028,6 +2029,7 @@ const bills: BillsConfig[] = [
     clickUpId: '86agqjvbk',
     cgId: 'planet-ix',
     vestingCliff: 864000, //10 days cliff, 20 days linear vesting
+    tierBoostRate: 0,
   },
   {
     index: 8097,


### PR DESCRIPTION
## Summary
- add `tierBoostRate: 0` to both Planet IX bill entries in `src/constants/bills.ts`
- mirror the same `tierBoostRate` values in `config/bills.json` to keep generated and source config aligned
- keep behavior explicit for these two offers without changing other bill fields

## Test plan
- [x] run `jest`
- [x] verify only Planet IX entries were updated