### PR TITLE
chore: mark iREET bond as sold out

### DIFF
--- a/config/bills.json
+++ b/config/bills.json
@@ -39818,7 +39818,7 @@
     "initTime": {
       "1": 1776111382
     },
-    "soldOut": false,
+    "soldOut": true,
     "hide": false,
     "billArt": {
       "collection": "ETH_Collection1"

--- a/src/constants/bills.ts
+++ b/src/constants/bills.ts
@@ -21269,7 +21269,7 @@ With the lending products set to go live in February, the project is poised to a
     projectLink: 'https://www.instruxi.io/',
     twitter: 'https://x.com/instruxi',
     initTime: { [ChainId.MAINNET]: 1776111382 },
-    soldOut: false,
+    soldOut: true,
     hide: false,
     billArt: {
       collection: BillArtCollection.ETH_Collection1,


### PR DESCRIPTION
## Summary
- set the iREET bond entry to `soldOut: true` in `src/constants/bills.ts`
- regenerate `config/bills.json` via build output to keep exported config in sync
- verified the change by running `yarn build`

## Test plan
- [x] Run `yarn build`
- [x] Confirm iREET bond now has `soldOut: true` in source and generated config